### PR TITLE
Werkzeug/routing

### DIFF
--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
@@ -24,7 +24,7 @@ public class Map {
     this(ruleFactories, "", false);
   }
 
-  private void add(RuleFactory ruleFactory) {
+  public void add(RuleFactory ruleFactory) {
     for (Rule rule : ruleFactory.getRules()) {
       rule.bind(this, false);
       this.rules.add(rule);

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
@@ -11,6 +11,7 @@ public class Map {
   public String defaultSubdomain = "";
   public boolean hostMatching = false;
 
+  /** The map class stores all the URL rules and some configuration parameters. */
   public Map(List<RuleFactory> ruleFactories, String defaultSubdomain, boolean hostMatching) {
     for (RuleFactory ruleFactory : ruleFactories) {
       this.add(ruleFactory);
@@ -27,8 +28,9 @@ public class Map {
     for (Rule rule : ruleFactory.getRules()) {
       rule.bind(this, false);
       this.rules.add(rule);
-      if (!this.rulesByEndpoint.containsKey(rule.endpoint))
+      if (!this.rulesByEndpoint.containsKey(rule.endpoint)) {
         this.rulesByEndpoint.put(rule.endpoint, new ArrayList<Rule>());
+      }
       this.rulesByEndpoint.get(rule.endpoint).add(rule);
     }
     this.remap = true;

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
@@ -3,6 +3,7 @@ package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
 import java.util.List;
 
 public class Map {
+    String defaultSubDomain = "";
     public Map(List<RuleFactory> rules) {
 
     }

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
@@ -1,0 +1,21 @@
+package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
+
+import java.util.List;
+
+public class Map {
+    public Map(List<RuleFactory> rules) {
+
+    }
+    private void add(RuleFactory rule) {
+
+    }
+    public MapAdapter bind(String serverName) {
+        return null;
+    }
+    // public MapAdapter bind(WSGIEnvironment environ, String serverName) {
+    // }
+    public void update() {
+
+    }
+}
+

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
@@ -5,17 +5,23 @@ import java.util.HashMap;
 import java.util.List;
 
 public class Map {
-    String defaultSubDomain = "";
-    private ArrayList<Rule> rules = new ArrayList<>();
+    public ArrayList<Rule> rules = new ArrayList<>();
     private HashMap<String, ArrayList<Rule>> rulesByEndpoint = new HashMap<>();
     private boolean remap = true;
-    private String defaultSubdomain;
-    public Map(List<RuleFactory> ruleFactories, String defaultSubdomain) {
+    public String defaultSubdomain = "";
+    public boolean hostMatching = false;
+
+    public Map(List<RuleFactory> ruleFactories, String defaultSubdomain, boolean hostMatching) {
         for (RuleFactory ruleFactory: ruleFactories) {
             this.add(ruleFactory);
         }
         this.defaultSubdomain = defaultSubdomain;
+        this.hostMatching = hostMatching;
     }
+    public Map(List<RuleFactory> ruleFactories) {
+        this(ruleFactories, "", false);
+    }
+
     private void add(RuleFactory ruleFactory) {
         for (Rule rule: ruleFactory.getRules()) {
             rule.bind(this, false); 
@@ -26,16 +32,18 @@ public class Map {
         }
         this.remap = true;
     }
+
     public MapAdapter bind(String serverName) {
         return this.bind(serverName, "/", this.defaultSubdomain, "http", "GET", "/");
     }
-    public MapAdapter bind(String serverName, String scriptName, String subdomain, String urlScheme, String defaultMethod, String pathInfo) {
-        return MapAdapter(this, serverName, scriptName, subdomain, urlScheme, pathInfo, defaultMethod);
+    public MapAdapter bind(String serverName, String scriptName) {
+        return this.bind(serverName, scriptName, this.defaultSubdomain, "http", "GET", "/");
     }
+    public MapAdapter bind(String serverName, String scriptName, String subdomain, String urlScheme, String defaultMethod, String pathInfo) {
+        return new MapAdapter(this, serverName, scriptName, subdomain, urlScheme, pathInfo, defaultMethod);
+    }
+
     // public MapAdapter bindToEnvironment(WSGIEnvironment environ, String serverName) {
     // }
-    public void update() {
-
-    }
 }
 

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
@@ -24,6 +24,9 @@ public class Map {
     this(ruleFactories, "", false);
   }
 
+  /** Use passed ruleFactory to created rules and put them into this map.
+   * All rules created is bound to this map (therefore compiled)
+   */
   public void add(RuleFactory ruleFactory) {
     for (Rule rule : ruleFactory.getRules()) {
       rule.bind(this, false);

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
@@ -49,6 +49,7 @@ public class Map {
     return this.bind(serverName, scriptName, null, null, null, null);
   }
 
+  /** Return a new :class:`MapAdapter` with the details specified to the call. */
   public MapAdapter bind(
       String serverName,
       String scriptName,
@@ -56,48 +57,56 @@ public class Map {
       String urlScheme,
       String defaultMethod,
       String pathInfo) {
-      if (scriptName == null) {
-          scriptName = "/";
-      }
-      if (subdomain == null) {
-          subdomain = this.defaultSubdomain;
-      }
-      if (pathInfo == null) {
-          pathInfo = "/";
-      }
+    if (scriptName == null) {
+      scriptName = "/";
+    }
+    if (subdomain == null) {
+      subdomain = this.defaultSubdomain;
+    }
+    if (pathInfo == null) {
+      pathInfo = "/";
+    }
 
-      if (urlScheme == null) {
-          urlScheme = "http";
-      }
-      if (defaultMethod == null) {
-          defaultMethod = "GET";
-      }
+    if (urlScheme == null) {
+      urlScheme = "http";
+    }
+    if (defaultMethod == null) {
+      defaultMethod = "GET";
+    }
     return new MapAdapter(
         this, serverName, scriptName, subdomain, urlScheme, pathInfo, defaultMethod);
   }
 
-  public MapAdapter bindToEnvironment(HashMap<String, Object> environ, String serverName, String subdomain) {
-      String wsgiServerName = (String) environ.get("SERVER_NAME");
-      wsgiServerName = wsgiServerName.toLowerCase();
-      if (serverName == null) {
-          serverName = wsgiServerName;
-      } else {
-          serverName = serverName.toLowerCase();
-      }
+  /**
+   * Like :meth:`bind` but you can pass it an WSGI environment and it will fetch the information
+   * from that dictionary.
+   */
+  public MapAdapter bindToEnvironment(
+      HashMap<String, Object> environ, String serverName, String subdomain) {
 
-      if (subdomain == null && !this.hostMatching) {
-          String[] curServerName = wsgiServerName.split(".");
-          String[] realServerName = serverName.split(".");
-          // TODO: handle subdomain invalid, set subdomain = "<invalid>" like werkzeug
-          String[] subdomainParts = Arrays.copyOfRange(curServerName, 0, curServerName.length - realServerName.length);
-          subdomain = String.join(".", subdomainParts);
-      }
-
-      // TODO: check theses values are currecttly fetched from environ after its functionalities are implemented
-      String scriptName = (String) environ.get("SCRIPT_NAME");
-      String urlScheme = (String) environ.get("wsgi.url_scheme");
-      String pathInfo = (String) environ.get("PATH_INFO");
-      String defaultMethod = (String) environ.get("REQUEST_METHOD");
-      return this.bind(serverName, scriptName, subdomain, urlScheme, defaultMethod, pathInfo);
+    String wsgiServerName = (String) environ.get("SERVER_NAME");
+    wsgiServerName = wsgiServerName.toLowerCase();
+    if (serverName == null) {
+      serverName = wsgiServerName;
+    } else {
+      serverName = serverName.toLowerCase();
     }
+
+    if (subdomain == null && !this.hostMatching) {
+      String[] curServerName = wsgiServerName.split(".");
+      String[] realServerName = serverName.split(".");
+      // TODO: handle subdomain invalid, set subdomain = "<invalid>" like werkzeug
+      String[] subdomainParts =
+          Arrays.copyOfRange(curServerName, 0, curServerName.length - realServerName.length);
+      subdomain = String.join(".", subdomainParts);
+    }
+
+    // TODO: check theses values are currecttly fetched from environ after its functionalities are
+    // implemented
+    String scriptName = (String) environ.get("SCRIPT_NAME");
+    String urlScheme = (String) environ.get("wsgi.url_scheme");
+    String pathInfo = (String) environ.get("PATH_INFO");
+    String defaultMethod = (String) environ.get("REQUEST_METHOD");
+    return this.bind(serverName, scriptName, subdomain, urlScheme, defaultMethod, pathInfo);
+  }
 }

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
@@ -82,7 +82,7 @@ public class Map {
    * from that dictionary.
    */
   public MapAdapter bindToEnvironment(
-      HashMap<String, Object> environ, String serverName, String subdomain) {
+      java.util.Map<String, Object> environ, String serverName, String subdomain) {
 
     String wsgiServerName = (String) environ.get("SERVER_NAME");
     wsgiServerName = wsgiServerName.toLowerCase();

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
@@ -1,19 +1,38 @@
 package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 public class Map {
     String defaultSubDomain = "";
-    public Map(List<RuleFactory> rules) {
-
+    private ArrayList<Rule> rules = new ArrayList<>();
+    private HashMap<String, ArrayList<Rule>> rulesByEndpoint = new HashMap<>();
+    private boolean remap = true;
+    private String defaultSubdomain;
+    public Map(List<RuleFactory> ruleFactories, String defaultSubdomain) {
+        for (RuleFactory ruleFactory: ruleFactories) {
+            this.add(ruleFactory);
+        }
+        this.defaultSubdomain = defaultSubdomain;
     }
-    private void add(RuleFactory rule) {
-
+    private void add(RuleFactory ruleFactory) {
+        for (Rule rule: ruleFactory.getRules()) {
+            rule.bind(this, false); 
+            this.rules.add(rule);
+            if (!this.rulesByEndpoint.containsKey(rule.endpoint))
+                this.rulesByEndpoint.put(rule.endpoint, new ArrayList<Rule>());
+            this.rulesByEndpoint.get(rule.endpoint).add(rule);
+        }
+        this.remap = true;
     }
     public MapAdapter bind(String serverName) {
-        return null;
+        return this.bind(serverName, "/", this.defaultSubdomain, "http", "GET", "/");
     }
-    // public MapAdapter bind(WSGIEnvironment environ, String serverName) {
+    public MapAdapter bind(String serverName, String scriptName, String subdomain, String urlScheme, String defaultMethod, String pathInfo) {
+        return MapAdapter(this, serverName, scriptName, subdomain, urlScheme, pathInfo, defaultMethod);
+    }
+    // public MapAdapter bindToEnvironment(WSGIEnvironment environ, String serverName) {
     // }
     public void update() {
 

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
@@ -24,8 +24,9 @@ public class Map {
     this(ruleFactories, "", false);
   }
 
-  /** Use passed ruleFactory to created rules and put them into this map.
-   * All rules created is bound to this map (therefore compiled)
+  /**
+   * Use passed ruleFactory to created rules and put them into this map. All rules created is bound
+   * to this map (therefore compiled)
    */
   public void add(RuleFactory ruleFactory) {
     for (Rule rule : ruleFactory.getRules()) {

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Map.java
@@ -5,45 +5,54 @@ import java.util.HashMap;
 import java.util.List;
 
 public class Map {
-    public ArrayList<Rule> rules = new ArrayList<>();
-    private HashMap<String, ArrayList<Rule>> rulesByEndpoint = new HashMap<>();
-    private boolean remap = true;
-    public String defaultSubdomain = "";
-    public boolean hostMatching = false;
+  public ArrayList<Rule> rules = new ArrayList<>();
+  private HashMap<String, ArrayList<Rule>> rulesByEndpoint = new HashMap<>();
+  private boolean remap = true;
+  public String defaultSubdomain = "";
+  public boolean hostMatching = false;
 
-    public Map(List<RuleFactory> ruleFactories, String defaultSubdomain, boolean hostMatching) {
-        for (RuleFactory ruleFactory: ruleFactories) {
-            this.add(ruleFactory);
-        }
-        this.defaultSubdomain = defaultSubdomain;
-        this.hostMatching = hostMatching;
+  public Map(List<RuleFactory> ruleFactories, String defaultSubdomain, boolean hostMatching) {
+    for (RuleFactory ruleFactory : ruleFactories) {
+      this.add(ruleFactory);
     }
-    public Map(List<RuleFactory> ruleFactories) {
-        this(ruleFactories, "", false);
-    }
+    this.defaultSubdomain = defaultSubdomain;
+    this.hostMatching = hostMatching;
+  }
 
-    private void add(RuleFactory ruleFactory) {
-        for (Rule rule: ruleFactory.getRules()) {
-            rule.bind(this, false); 
-            this.rules.add(rule);
-            if (!this.rulesByEndpoint.containsKey(rule.endpoint))
-                this.rulesByEndpoint.put(rule.endpoint, new ArrayList<Rule>());
-            this.rulesByEndpoint.get(rule.endpoint).add(rule);
-        }
-        this.remap = true;
-    }
+  public Map(List<RuleFactory> ruleFactories) {
+    this(ruleFactories, "", false);
+  }
 
-    public MapAdapter bind(String serverName) {
-        return this.bind(serverName, "/", this.defaultSubdomain, "http", "GET", "/");
+  private void add(RuleFactory ruleFactory) {
+    for (Rule rule : ruleFactory.getRules()) {
+      rule.bind(this, false);
+      this.rules.add(rule);
+      if (!this.rulesByEndpoint.containsKey(rule.endpoint))
+        this.rulesByEndpoint.put(rule.endpoint, new ArrayList<Rule>());
+      this.rulesByEndpoint.get(rule.endpoint).add(rule);
     }
-    public MapAdapter bind(String serverName, String scriptName) {
-        return this.bind(serverName, scriptName, this.defaultSubdomain, "http", "GET", "/");
-    }
-    public MapAdapter bind(String serverName, String scriptName, String subdomain, String urlScheme, String defaultMethod, String pathInfo) {
-        return new MapAdapter(this, serverName, scriptName, subdomain, urlScheme, pathInfo, defaultMethod);
-    }
+    this.remap = true;
+  }
 
-    // public MapAdapter bindToEnvironment(WSGIEnvironment environ, String serverName) {
-    // }
+  public MapAdapter bind(String serverName) {
+    return this.bind(serverName, "/", this.defaultSubdomain, "http", "GET", "/");
+  }
+
+  public MapAdapter bind(String serverName, String scriptName) {
+    return this.bind(serverName, scriptName, this.defaultSubdomain, "http", "GET", "/");
+  }
+
+  public MapAdapter bind(
+      String serverName,
+      String scriptName,
+      String subdomain,
+      String urlScheme,
+      String defaultMethod,
+      String pathInfo) {
+    return new MapAdapter(
+        this, serverName, scriptName, subdomain, urlScheme, pathInfo, defaultMethod);
+  }
+
+  // public MapAdapter bindToEnvironment(WSGIEnvironment environ, String serverName) {
+  // }
 }
-

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapter.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapter.java
@@ -1,18 +1,39 @@
 package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
 
+import java.util.HashMap;
+
 import javafx.util.Pair;
 
 public class MapAdapter {
-    public MapAdapter(
-        Map map, String serverName, String scriptName, String subdomain,
-        String urlScheme, String pathInfo, String defaultMethod) {
+
+    private Map map;
+    private String serverName, scriptName, subdomain, urlScheme, pathInfo, defaultMethod;
+    public MapAdapter(Map map, String serverName, String scriptName, String subdomain, String urlScheme, String pathInfo, String defaultMethod) {
+        this.map = map;
+        this.serverName = serverName;
+        this.scriptName = scriptName;
+        this.subdomain = subdomain;
+        this.urlScheme = urlScheme;
+        this.pathInfo = pathInfo;
+        this.defaultMethod = defaultMethod;
     }
-    // public Response dispatch(ViewFunction viewFunc) {
-    public Object dispatch(Object viewFunc) {
+    public Pair<Rule, HashMap<String, Integer>> match() {
         return null;
     }
-    public Pair<String, Object[]> match() {
-        return null;
+    public Pair<Rule, HashMap<String, Integer>> match(String pathInfo, String method) {
+        StringBuilder sb = new StringBuilder();
+        if (this.map.hostMatching) sb.append(this.serverName);
+        else sb.append(this.subdomain);
+        sb.append("|").append(this.pathInfo);
+        String path = sb.toString();
+
+        for (Rule rule: this.map.rules) {
+            HashMap<String, Integer> returnValue = rule.match(path);
+            if (returnValue == null) continue;
+            // TODO: raise RequestSlash or RequestRedirect under some circumstances
+            return new Pair<>(rule, returnValue);
+        }
+        throw new RuntimeException("All rules not matched");  // TODO: use a custom NotFound excpetion.
     }
 }
 

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapter.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapter.java
@@ -17,21 +17,26 @@ public class MapAdapter {
         this.pathInfo = pathInfo;
         this.defaultMethod = defaultMethod;
     }
-    public Pair<Rule, HashMap<String, Integer>> match() {
-        return null;
+    public Pair<String, HashMap<String, Integer>> match(String pathInfo) {
+        return this.match(pathInfo, this.defaultMethod.toUpperCase());
     }
-    public Pair<Rule, HashMap<String, Integer>> match(String pathInfo, String method) {
+    public Pair<String, HashMap<String, Integer>> match(String pathInfo, String method) {
+        /** Search through all rules in the bound map, return the first rule
+         * that match this pathInfo and its corresponding arguments.
+         */
         StringBuilder sb = new StringBuilder();
         if (this.map.hostMatching) sb.append(this.serverName);
         else sb.append(this.subdomain);
-        sb.append("|").append(this.pathInfo);
+        sb.append("|");
+        sb.append(pathInfo);
         String path = sb.toString();
+
 
         for (Rule rule: this.map.rules) {
             HashMap<String, Integer> returnValue = rule.match(path);
             if (returnValue == null) continue;
             // TODO: raise RequestSlash or RequestRedirect under some circumstances
-            return new Pair<>(rule, returnValue);
+            return new Pair<>(rule.endpoint, returnValue);
         }
         throw new RuntimeException("All rules not matched");  // TODO: use a custom NotFound excpetion.
     }

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapter.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapter.java
@@ -1,46 +1,52 @@
 package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
 
 import java.util.HashMap;
-
 import javafx.util.Pair;
 
 public class MapAdapter {
 
-    private Map map;
-    private String serverName, scriptName, subdomain, urlScheme, pathInfo, defaultMethod;
-    public MapAdapter(Map map, String serverName, String scriptName, String subdomain, String urlScheme, String pathInfo, String defaultMethod) {
-        this.map = map;
-        this.serverName = serverName;
-        this.scriptName = scriptName;
-        this.subdomain = subdomain;
-        this.urlScheme = urlScheme;
-        this.pathInfo = pathInfo;
-        this.defaultMethod = defaultMethod;
-    }
-    public Pair<String, HashMap<String, Integer>> match(String pathInfo) {
-        return this.match(pathInfo, this.defaultMethod.toUpperCase());
-    }
-    public Pair<String, HashMap<String, Integer>> match(String pathInfo, String method) {
-        /** Search through all rules in the bound map, return the first rule
-         * that match this pathInfo and its corresponding arguments.
-         */
-        StringBuilder sb = new StringBuilder();
-        if (this.map.hostMatching) sb.append(this.serverName);
-        else sb.append(this.subdomain);
-        sb.append("|");
-        sb.append(pathInfo);
-        String path = sb.toString();
+  private Map map;
+  private String serverName, scriptName, subdomain, urlScheme, pathInfo, defaultMethod;
 
+  public MapAdapter(
+      Map map,
+      String serverName,
+      String scriptName,
+      String subdomain,
+      String urlScheme,
+      String pathInfo,
+      String defaultMethod) {
+    this.map = map;
+    this.serverName = serverName;
+    this.scriptName = scriptName;
+    this.subdomain = subdomain;
+    this.urlScheme = urlScheme;
+    this.pathInfo = pathInfo;
+    this.defaultMethod = defaultMethod;
+  }
 
-        for (Rule rule: this.map.rules) {
-            HashMap<String, Integer> returnValue = rule.match(path);
-            if (returnValue == null) continue;
-            // TODO: raise RequestSlash or RequestRedirect under some circumstances
-            return new Pair<>(rule.endpoint, returnValue);
-        }
-        throw new RuntimeException("All rules not matched");  // TODO: use a custom NotFound excpetion.
+  public Pair<String, HashMap<String, Integer>> match(String pathInfo) {
+    return this.match(pathInfo, this.defaultMethod.toUpperCase());
+  }
+
+  public Pair<String, HashMap<String, Integer>> match(String pathInfo, String method) {
+    /**
+     * Search through all rules in the bound map, return the first rule that match this pathInfo and
+     * its corresponding arguments.
+     */
+    StringBuilder sb = new StringBuilder();
+    if (this.map.hostMatching) sb.append(this.serverName);
+    else sb.append(this.subdomain);
+    sb.append("|");
+    sb.append(pathInfo);
+    String path = sb.toString();
+
+    for (Rule rule : this.map.rules) {
+      HashMap<String, Integer> returnValue = rule.match(path);
+      if (returnValue == null) continue;
+      // TODO: raise RequestSlash or RequestRedirect under some circumstances
+      return new Pair<>(rule.endpoint, returnValue);
     }
+    throw new RuntimeException("All rules not matched"); // TODO: use a custom NotFound excpetion.
+  }
 }
-
-
-

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapter.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapter.java
@@ -3,8 +3,9 @@ package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
 import javafx.util.Pair;
 
 public class MapAdapter {
-    public MapAdapter(Map map, String serverName) {
-
+    public MapAdapter(
+        Map map, String serverName, String scriptName, String subdomain,
+        String urlScheme, String pathInfo, String defaultMethod) {
     }
     // public Response dispatch(ViewFunction viewFunc) {
     public Object dispatch(Object viewFunc) {

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapter.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapter.java
@@ -34,7 +34,7 @@ public class MapAdapter {
     this.defaultMethod = defaultMethod;
   }
 
-  public Pair<String, HashMap<String, Integer>> match(String pathInfo) {
+  public Pair<String, HashMap<String, Object>> match(String pathInfo) {
     return this.match(pathInfo, this.defaultMethod.toUpperCase());
   }
 
@@ -42,7 +42,7 @@ public class MapAdapter {
    * Search through all rules in the bound map, return the first rule that match this pathInfo and
    * its corresponding arguments.
    */
-  public Pair<String, HashMap<String, Integer>> match(String pathInfo, String method) {
+  public Pair<String, HashMap<String, Object>> match(String pathInfo, String method) {
     StringBuilder sb = new StringBuilder();
     if (this.map.hostMatching) {
       sb.append(this.serverName);
@@ -54,7 +54,7 @@ public class MapAdapter {
     String path = sb.toString();
 
     for (Rule rule : this.map.rules) {
-      HashMap<String, Integer> returnValue = rule.match(path);
+      HashMap<String, Object> returnValue = rule.match(path);
       if (returnValue == null) {
         continue;
       }

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapter.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapter.java
@@ -6,8 +6,17 @@ import javafx.util.Pair;
 public class MapAdapter {
 
   private Map map;
-  private String serverName, scriptName, subdomain, urlScheme, pathInfo, defaultMethod;
+  private String serverName;
+  private String scriptName;
+  private String subdomain;
+  private String urlScheme;
+  private String pathInfo;
+  private String defaultMethod;
 
+  /**
+   * Returned by :meth:`Map.bind` or :meth:`Map.bind_to_environ` and does the URL matching and
+   * building based on runtime information.
+   */
   public MapAdapter(
       Map map,
       String serverName,
@@ -29,21 +38,26 @@ public class MapAdapter {
     return this.match(pathInfo, this.defaultMethod.toUpperCase());
   }
 
+  /**
+   * Search through all rules in the bound map, return the first rule that match this pathInfo and
+   * its corresponding arguments.
+   */
   public Pair<String, HashMap<String, Integer>> match(String pathInfo, String method) {
-    /**
-     * Search through all rules in the bound map, return the first rule that match this pathInfo and
-     * its corresponding arguments.
-     */
     StringBuilder sb = new StringBuilder();
-    if (this.map.hostMatching) sb.append(this.serverName);
-    else sb.append(this.subdomain);
+    if (this.map.hostMatching) {
+      sb.append(this.serverName);
+    } else {
+      sb.append(this.subdomain);
+    }
     sb.append("|");
     sb.append(pathInfo);
     String path = sb.toString();
 
     for (Rule rule : this.map.rules) {
       HashMap<String, Integer> returnValue = rule.match(path);
-      if (returnValue == null) continue;
+      if (returnValue == null) {
+        continue;
+      }
       // TODO: raise RequestSlash or RequestRedirect under some circumstances
       return new Pair<>(rule.endpoint, returnValue);
     }

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapter.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapter.java
@@ -1,0 +1,19 @@
+package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
+
+import javafx.util.Pair;
+
+public class MapAdapter {
+    public MapAdapter(Map map, String serverName) {
+
+    }
+    // public Response dispatch(ViewFunction viewFunc) {
+    public Object dispatch(Object viewFunc) {
+        return null;
+    }
+    public Pair<String, Object[]> match() {
+        return null;
+    }
+}
+
+
+

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
@@ -190,6 +190,7 @@ public class Rule implements RuleFactory {
 
   interface RegexConverter {
     public String getRegex();
+
     public Object parse(String variableStr);
   }
 
@@ -203,7 +204,7 @@ public class Rule implements RuleFactory {
 
     @Override
     public Object parse(String variableStr) {
-        return Integer.parseInt(variableStr);
+      return Integer.parseInt(variableStr);
     }
   }
   // TODO: implement more converters, e.g. float, path, uuid...

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
@@ -2,23 +2,73 @@ package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class Rule implements RuleFactory {
-    public Rule(String string, Object endpoint) {
+    public String rule;
+    public String subDomain = null;
+    private Map map = null;
+    private Pattern regex;
 
+    public Rule(String string, Object endpoint) {
+        this.rule = string;
+    }
+    public Rule(String string, Object endpoint, String subDomain) {
+        this.rule = string;
+        this.subDomain = subDomain;
     }
     @Override
     public ArrayList<Rule> getRules() {
-        return new ArrayList<>();
+        ArrayList<Rule> ret = new ArrayList<Rule>();
+        ret.add(this);
+        return ret;
     }
-    public void bind(Map map) {
 
+    public void bind(Map map, boolean rebind) {
+        if (this.map != null && rebind) throw new RuntimeException("Already bound.");
+        this.map = map;
+        if (this.subDomain == null) this.subDomain = map.defaultSubDomain;
+        this.compile();
     }
     public void compile() {
-
+        /** compile the regular expression and stores it */
+        ArrayList<String> regex_parts = new ArrayList<String>();
+        for (ParseResult result: Utilities.parseRuleHelper(this.rule)) {
+            regex_parts.add(String.format(
+                "(?<%s>%s)", result.variable, result.converter.regex
+            ));
+        }
+        regex_parts.add("\\|");
+        // the second part "(?<!/)(?P<__suffix__>/?)" currently not supported.
+        String regex = String.format("^%s", String.join("", regex_parts));
+        this.regex = Pattern.compile(regex);
     }
-    public HashMap<Object, Object> match() {
+    public HashMap<String, Integer> match(String path) {
+        /**Check if the rule matched a given path in the form "subdomain|/path" and
+         * is assembled by the Map. If matched, return converted values in a dict.
+         * Otherwise null will be returned.
+         */
+        
         return null;
     }
 }
 
+
+class ParseResult {
+    public Converter converter;
+    public String[] arguments;
+    public String variable;
+}
+class Utilities {
+    static public ArrayList<ParseResult> parseRuleHelper(String rule) {
+        return null;
+    }
+}
+
+class Converter {
+    public String regex = "";
+}
+class IntegerConverter extends Converter {
+    public String regex = "-?\\d+";
+}

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
@@ -15,13 +15,13 @@ public class Rule implements RuleFactory {
   private Map map = null;
   private Pattern regex;
 
-  /** A Rule represents one URL pattern.*/
+  /** A Rule represents one URL pattern. */
   public Rule(String string, String endpoint) {
     this.rule = string;
     this.endpoint = endpoint;
   }
 
-  /** Constructor with argument subdomain and host.*/
+  /** Constructor with argument subdomain and host. */
   public Rule(String string, String endpoint, String subdomain, String host) {
     this.rule = string;
     this.endpoint = endpoint;
@@ -36,8 +36,9 @@ public class Rule implements RuleFactory {
     return ret;
   }
 
-  /** Bind the url to a map and create a regular expression based on
-   * the information from the rule itself and the defaults from the map.
+  /**
+   * Bind the url to a map and create a regular expression based on the information from the rule
+   * itself and the defaults from the map.
    */
   public void bind(Map map, boolean rebind) {
     if (this.map != null && rebind) {
@@ -75,12 +76,11 @@ public class Rule implements RuleFactory {
     this.regex = Pattern.compile(regex);
   }
 
-  /** Check if the rule matches a given path. Path is a string in the
-   * form ``"subdomain|/path"`` and is assembled by the map.  If
-   * the map is doing host matching the subdomain part will be the host
-   * instead.
-   * If the rule matches a HashMap with the converted values is returned,
-   * otherwise the return value is `null`.
+  /**
+   * Check if the rule matches a given path. Path is a string in the form ``"subdomain|/path"`` and
+   * is assembled by the map. If the map is doing host matching the subdomain part will be the host
+   * instead. If the rule matches a HashMap with the converted values is returned, otherwise the
+   * return value is `null`.
    */
   public HashMap<String, Integer> match(String path) {
     Matcher matcher = this.regex.matcher(path);
@@ -145,10 +145,9 @@ public class Rule implements RuleFactory {
     private final Pattern ruleRegex =
         Pattern.compile(
             "(?<static>[^<]*)"
-            + "<(?:(?<converter>[a-zA-Z_][a-zA-Z0-9_]*)"
-            + "(?:\\((?<args>.*?)\\))?\\:)?"
-            + "(?<variable>[a-zA-Z_][a-zA-Z0-9_]*)>"
-        );
+                + "<(?:(?<converter>[a-zA-Z_][a-zA-Z0-9_]*)"
+                + "(?:\\((?<args>.*?)\\))?\\:)?"
+                + "(?<variable>[a-zA-Z_][a-zA-Z0-9_]*)>");
     private final String[] targets = {"static", "converter", "args", "variable"};
 
     public ArrayList<RuleParseResult> parse(String rule) {

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
@@ -7,16 +7,19 @@ import java.util.regex.Pattern;
 
 public class Rule implements RuleFactory {
     public String rule;
+    public String endpoint;
     public String subDomain = null;
     private Map map = null;
     private Pattern regex;
 
-    public Rule(String string, Object endpoint) {
+    public Rule(String string, String endpoint) {
         this.rule = string;
+        this.endpoint = endpoint;
     }
-    public Rule(String string, Object endpoint, String subDomain) {
+    public Rule(String string, String endpoint, String subDomain) {
         this.rule = string;
         this.subDomain = subDomain;
+        this.endpoint = endpoint;
     }
     @Override
     public ArrayList<Rule> getRules() {

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
@@ -8,164 +8,170 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class Rule implements RuleFactory {
-    public String rule;
-    public String endpoint;
-    public String subdomain;
-    public String host;
-    private Map map = null;
-    private Pattern regex;
+  public String rule;
+  public String endpoint;
+  public String subdomain;
+  public String host;
+  private Map map = null;
+  private Pattern regex;
 
-    public Rule(String string, String endpoint) {
-        this.rule = string;
-        this.endpoint = endpoint;
-    }
-    public Rule(String string, String endpoint, String subdomain, String host) {
-        this.rule = string;
-        this.endpoint = endpoint;
-        this.subdomain = subdomain;
-        this.host = host;
-    }
-    @Override
-    public ArrayList<Rule> getRules() {
-        ArrayList<Rule> ret = new ArrayList<Rule>();
-        ret.add(this);
-        return ret;
-    }
+  public Rule(String string, String endpoint) {
+    this.rule = string;
+    this.endpoint = endpoint;
+  }
 
-    public void bind(Map map, boolean rebind) {
-        if (this.map != null && rebind) throw new RuntimeException("Already bound.");
-        this.map = map;
-        if (this.subdomain == null) this.subdomain = map.defaultSubdomain;
-        this.compile();
-    }
+  public Rule(String string, String endpoint, String subdomain, String host) {
+    this.rule = string;
+    this.endpoint = endpoint;
+    this.subdomain = subdomain;
+    this.host = host;
+  }
 
-    public void compile() {
-        /** compile the regular expression and stores it */
-        ArrayList<String> regexParts = new ArrayList<String>();
+  @Override
+  public ArrayList<Rule> getRules() {
+    ArrayList<Rule> ret = new ArrayList<Rule>();
+    ret.add(this);
+    return ret;
+  }
 
-        if (this.map.hostMatching) regexParts.add(this.host);
-        else regexParts.add(this.subdomain);
-        regexParts.add("\\|");
+  public void bind(Map map, boolean rebind) {
+    if (this.map != null && rebind) throw new RuntimeException("Already bound.");
+    this.map = map;
+    if (this.subdomain == null) this.subdomain = map.defaultSubdomain;
+    this.compile();
+  }
 
-        RuleParser ruleParser = new RuleParser();
-        for (RuleParseResult result: ruleParser.parse(this.rule)) {
-            // if converter is null, it's a static url part
-            if (result.converter == null) regexParts.add(result.variable);
-            else {
-                regexParts.add(String.format(
-                    "(?<%s>%s)", result.variable, result.converter.getRegex()
-                ));
-            }
-        }
-        // the second part "(?<!/)(?P<__suffix__>/?)" currently not supported.
-        String regex = String.format("^%s", String.join("", regexParts));
-        this.regex = Pattern.compile(regex);
-    }
+  public void compile() {
+    /** compile the regular expression and stores it */
+    ArrayList<String> regexParts = new ArrayList<String>();
 
-    public HashMap<String, Integer> match(String path) {
-        /**Check if the rule matched a given path in the form "subdomain|/path" and
-         * is assembled by the Map. If matched, return converted values in a dict.
-         * Otherwise null will be returned.
-         */
-        Matcher matcher = this.regex.matcher(path);
-        if(matcher.matches()) {
-            HashMap<String, Integer> ret = new HashMap<String, Integer>();
-            Set<String> groupNames = this.getNamedGroupCandidates(this.regex);
-            for (String groupName: groupNames) {
-                ret.put(groupName, Integer.parseInt(matcher.group(groupName)));
-            }
-            return ret;
-        }
-        else return null;
-    }
+    if (this.map.hostMatching) regexParts.add(this.host);
+    else regexParts.add(this.subdomain);
+    regexParts.add("\\|");
 
-    public Map getMap() {
-        return this.map;
+    RuleParser ruleParser = new RuleParser();
+    for (RuleParseResult result : ruleParser.parse(this.rule)) {
+      // if converter is null, it's a static url part
+      if (result.converter == null) regexParts.add(result.variable);
+      else {
+        regexParts.add(String.format("(?<%s>%s)", result.variable, result.converter.getRegex()));
+      }
     }
-    public String getRule() {
-        return this.rule;
+    // the second part "(?<!/)(?P<__suffix__>/?)" currently not supported.
+    String regex = String.format("^%s", String.join("", regexParts));
+    this.regex = Pattern.compile(regex);
+  }
+
+  public HashMap<String, Integer> match(String path) {
+    /**
+     * Check if the rule matched a given path in the form "subdomain|/path" and is assembled by the
+     * Map. If matched, return converted values in a dict. Otherwise null will be returned.
+     */
+    Matcher matcher = this.regex.matcher(path);
+    if (matcher.matches()) {
+      HashMap<String, Integer> ret = new HashMap<String, Integer>();
+      Set<String> groupNames = this.getNamedGroupCandidates(this.regex);
+      for (String groupName : groupNames) {
+        ret.put(groupName, Integer.parseInt(matcher.group(groupName)));
+      }
+      return ret;
+    } else return null;
+  }
+
+  public Map getMap() {
+    return this.map;
+  }
+
+  public String getRule() {
+    return this.rule;
+  }
+
+  public Pattern getRegex() {
+    return this.regex;
+  }
+
+  private Set<String> getNamedGroupCandidates(Pattern regexPattern) {
+    /** Find the names of named groups cause Java regex does not support to do so */
+    String regex = regexPattern.pattern();
+    Set<String> namedGroups = new TreeSet<String>();
+    Matcher m = Pattern.compile("\\(\\?<([a-zA-Z][a-zA-Z0-9]*)>").matcher(regex);
+    while (m.find()) {
+      namedGroups.add(m.group(1));
     }
-    public Pattern getRegex() {
-        return this.regex;
-    }
-	private Set<String> getNamedGroupCandidates(Pattern regexPattern) {
-        /**  Find the names of named groups cause Java regex does not support to do so
-         */
-        String regex = regexPattern.pattern();
-        Set<String> namedGroups = new TreeSet<String>();
-        Matcher m = Pattern.compile("\\(\\?<([a-zA-Z][a-zA-Z0-9]*)>").matcher(regex);
-        while (m.find()) {
-            namedGroups.add(m.group(1));
-        }
-        return namedGroups;
-    }
+    return namedGroups;
+  }
 }
 
 class RuleParseResult {
-    public RegexConverter converter;
-    public String arguments;
-    public String variable;
-    public RuleParseResult(RegexConverter converter, String arguments, String variable) {
-        this.converter = converter;
-        this.arguments = arguments;
-        this.variable = variable;
-    }
+  public RegexConverter converter;
+  public String arguments;
+  public String variable;
 
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("RuleParseResult{");
-        sb.append("converter = ").append(converter);
-        sb.append(", arguments = ").append(arguments);
-        sb.append(", variable = ").append(variable);
-        return sb.append("}").toString();
-    }
+  public RuleParseResult(RegexConverter converter, String arguments, String variable) {
+    this.converter = converter;
+    this.arguments = arguments;
+    this.variable = variable;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder("RuleParseResult{");
+    sb.append("converter = ").append(converter);
+    sb.append(", arguments = ").append(arguments);
+    sb.append(", variable = ").append(variable);
+    return sb.append("}").toString();
+  }
 }
 
 // Helper class for parsing rule to segments
 class RuleParser {
-    private final Pattern rule_re = Pattern.compile(
-            "(?<static>[^<]*)<(?:(?<converter>[a-zA-Z_][a-zA-Z0-9_]*)(?:\\((?<args>.*?)\\))?\\:)?(?<variable>[a-zA-Z_][a-zA-Z0-9_]*)>"
-            );
-    private final String[] targets = {"static", "converter", "args", "variable"};
-    public ArrayList<RuleParseResult> parse(String rule) {
-        Matcher matcher = rule_re.matcher(rule);
-        ArrayList<RuleParseResult> results = new ArrayList<RuleParseResult>();
-        int count_found = 0;
-        while (matcher.find()) {
-            count_found += 1;
-            String static_part = matcher.group("static");
-            RegexConverter converter = newConverter(matcher.group("converter"));
-            String args = matcher.group("args");
-            String variable = matcher.group("variable");
+  private final Pattern rule_re =
+      Pattern.compile(
+          "(?<static>[^<]*)<(?:(?<converter>[a-zA-Z_][a-zA-Z0-9_]*)(?:\\((?<args>.*?)\\))?\\:)?(?<variable>[a-zA-Z_][a-zA-Z0-9_]*)>");
+  private final String[] targets = {"static", "converter", "args", "variable"};
 
-            if (static_part != null) results.add(new RuleParseResult(null, null, static_part));
-            results.add(new RuleParseResult(converter, args, variable));
-        }
-        if (count_found == 0) {
-            // When the whole rule is static
-            results.add(new RuleParseResult(null, null, rule));
-        }
-        return results;
+  public ArrayList<RuleParseResult> parse(String rule) {
+    Matcher matcher = rule_re.matcher(rule);
+    ArrayList<RuleParseResult> results = new ArrayList<RuleParseResult>();
+    int count_found = 0;
+    while (matcher.find()) {
+      count_found += 1;
+      String static_part = matcher.group("static");
+      RegexConverter converter = newConverter(matcher.group("converter"));
+      String args = matcher.group("args");
+      String variable = matcher.group("variable");
+
+      if (static_part != null) results.add(new RuleParseResult(null, null, static_part));
+      results.add(new RuleParseResult(converter, args, variable));
     }
-    private RegexConverter newConverter(String converterStr) {
-        if (converterStr == null) return null;
-        if (converterStr.equals("int")) {
-            return new RegexIntegerConverter();
-        } else {
-            // TODO: throw a converter not found exception
-            return new RegexIntegerConverter();
-        }
+    if (count_found == 0) {
+      // When the whole rule is static
+      results.add(new RuleParseResult(null, null, rule));
     }
+    return results;
+  }
+
+  private RegexConverter newConverter(String converterStr) {
+    if (converterStr == null) return null;
+    if (converterStr.equals("int")) {
+      return new RegexIntegerConverter();
+    } else {
+      // TODO: throw a converter not found exception
+      return new RegexIntegerConverter();
+    }
+  }
 }
 
 interface RegexConverter {
-    public String getRegex();
+  public String getRegex();
 }
+
 class RegexIntegerConverter implements RegexConverter {
-    private String regex = "-?\\d+";
-    @Override
-    public String getRegex() {
-        return "-?\\d+";
-    }
+  private String regex = "-?\\d+";
+
+  @Override
+  public String getRegex() {
+    return "-?\\d+";
+  }
 }
 // TODO: implement more converters, e.g. float, path, uuid...

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 public class Rule implements RuleFactory {
     public String rule;
     public String endpoint;
-    public String subDomain = null;
+    public String subdomain = null;
     private Map map = null;
     private Pattern regex;
 
@@ -16,9 +16,9 @@ public class Rule implements RuleFactory {
         this.rule = string;
         this.endpoint = endpoint;
     }
-    public Rule(String string, String endpoint, String subDomain) {
+    public Rule(String string, String endpoint, String subdomain) {
         this.rule = string;
-        this.subDomain = subDomain;
+        this.subdomain = subdomain;
         this.endpoint = endpoint;
     }
     @Override
@@ -31,7 +31,7 @@ public class Rule implements RuleFactory {
     public void bind(Map map, boolean rebind) {
         if (this.map != null && rebind) throw new RuntimeException("Already bound.");
         this.map = map;
-        if (this.subDomain == null) this.subDomain = map.defaultSubDomain;
+        if (this.subdomain == null) this.subdomain = map.defaultSubdomain;
         this.compile();
     }
 
@@ -73,7 +73,6 @@ public class Rule implements RuleFactory {
         return this.regex;
     }
 }
-
 
 class RuleParseResult {
     public RegexConverter converter;

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
@@ -31,23 +31,26 @@ public class Rule implements RuleFactory {
         if (this.subDomain == null) this.subDomain = map.defaultSubDomain;
         this.compile();
     }
+
     public void compile() {
         /** compile the regular expression and stores it */
         ArrayList<String> regex_parts = new ArrayList<String>();
-        for (ParseResult result: Utilities.parseRuleHelper(this.rule)) {
+        RuleParser ruleParser = new RuleParser();
+        for (RuleParseResult result: ruleParser.parse(this.rule)) {
             // if converter is null, it's a static url part
             if (result.converter == null) regex_parts.add(result.variable);
             else {
                 regex_parts.add(String.format(
-                    "(?<%s>%s)", result.variable, result.converter.regex
+                    "(?<%s>%s)", result.variable, result.converter.getRegex()
                 ));
             }
         }
-        regex_parts.add("\\|");
         // the second part "(?<!/)(?P<__suffix__>/?)" currently not supported.
+        // regex_parts.add("\\|");
         String regex = String.format("^%s", String.join("", regex_parts));
         this.regex = Pattern.compile(regex);
     }
+
     public HashMap<String, Integer> match(String path) {
         /**Check if the rule matched a given path in the form "subdomain|/path" and
          * is assembled by the Map. If matched, return converted values in a dict.
@@ -69,49 +72,71 @@ public class Rule implements RuleFactory {
 }
 
 
-class ParseResult {
-    public Converter converter;
+class RuleParseResult {
+    public RegexConverter converter;
     public String arguments;
     public String variable;
-    public ParseResult(Converter converter, String arguments, String variable) {
+    public RuleParseResult(RegexConverter converter, String arguments, String variable) {
         this.converter = converter;
         this.arguments = arguments;
         this.variable = variable;
     }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("RuleParseResult{");
+        sb.append("converter = ").append(converter);
+        sb.append(", arguments = ").append(arguments);
+        sb.append(", variable = ").append(variable);
+        return sb.append("}").toString();
+    }
 }
-class Utilities {
-    static private final Pattern rule_re = Pattern.compile(
-        "(?<static>[^<]*)<(?:(?<converter>[a-zA-Z_][a-zA-Z0-9_]*)(?:\\((?<args>.*?)\\))?\\:)?(?<variable>[a-zA-Z_][a-zA-Z0-9_]*)>"
-    );
-    static private final String[] targets = {"static", "converter", "args", "variable"};
-    static public ArrayList<ParseResult> parseRuleHelper(String rule) {
+
+class RuleParser {
+    private final Pattern rule_re = Pattern.compile(
+            "(?<static>[^<]*)<(?:(?<converter>[a-zA-Z_][a-zA-Z0-9_]*)(?:\\((?<args>.*?)\\))?\\:)?(?<variable>[a-zA-Z_][a-zA-Z0-9_]*)>"
+            );
+    private final String[] targets = {"static", "converter", "args", "variable"};
+    public ArrayList<RuleParseResult> parse(String rule) {
         Matcher matcher = rule_re.matcher(rule);
-        ArrayList<ParseResult> results = new ArrayList<ParseResult>();
+        ArrayList<RuleParseResult> results = new ArrayList<RuleParseResult>();
+        int count_found = 0;
         while (matcher.find()) {
+            count_found += 1;
             String static_part = matcher.group("static");
-            Converter converter = newConverter(matcher.group("converter"));
+            RegexConverter converter = newConverter(matcher.group("converter"));
             String args = matcher.group("args");
             String variable = matcher.group("variable");
 
-            if (static_part != null) results.add(new ParseResult(null, null, static_part));
-            results.add(new ParseResult(converter, args, static_part));
+            if (static_part != null) results.add(new RuleParseResult(null, null, static_part));
+            results.add(new RuleParseResult(converter, args, variable));
         }
+        if (count_found == 0) {
+            // When the whole rule is static
+            results.add(new RuleParseResult(null, null, rule));
+        }
+        System.out.println("parsed results: " + results);
         return results;
     }
-    static private Converter newConverter(String converterStr) {
+    private RegexConverter newConverter(String converterStr) {
         if (converterStr == null) return null;
         if (converterStr.equals("int")) {
-            return new IntegerConverter();
+            return new RegexIntegerConverter();
         } else {
-            // TODO: implement a converter not found exception?
-            return new IntegerConverter();
+            // TODO: throw a converter not found exception
+            return new RegexIntegerConverter();
         }
     }
 }
 
-class Converter {
-    public String regex = "";
+interface RegexConverter {
+    public String getRegex();
 }
-class IntegerConverter extends Converter {
-    public String regex = "-?\\d+";
+class RegexIntegerConverter implements RegexConverter {
+    private String regex = "-?\\d+";
+    @Override
+    public String getRegex() {
+        return "-?\\d+";
+    }
 }
+// TODO: implement more converters, e.g. float, path, uuid...

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
@@ -2,6 +2,8 @@ package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -59,8 +61,16 @@ public class Rule implements RuleFactory {
          * is assembled by the Map. If matched, return converted values in a dict.
          * Otherwise null will be returned.
          */
-        
-        return null;
+        Matcher matcher = this.regex.matcher(rule);
+        if(matcher.find()) {
+            HashMap<String, Integer> ret = new HashMap<String, Integer>();
+            Set<String> groupNames = this.getNamedGroupCandidates(this.regex);
+            for (String groupName: groupNames) {
+                ret.put(groupName, Integer.parseInt(matcher.group(groupName)));
+            }
+            return ret;
+        }
+        else return null;
     }
 
     public Map getMap() {
@@ -71,6 +81,15 @@ public class Rule implements RuleFactory {
     }
     public Pattern getRegex() {
         return this.regex;
+    }
+	private Set<String> getNamedGroupCandidates(Pattern regexPattern) {
+        String regex = regexPattern.pattern();
+        Set<String> namedGroups = new TreeSet<String>();
+        Matcher m = Pattern.compile("\\(\\?<([a-zA-Z][a-zA-Z0-9]*)>").matcher(regex);
+        while (m.find()) {
+            namedGroups.add(m.group(1));
+        }
+        return namedGroups;
     }
 }
 
@@ -94,6 +113,7 @@ class RuleParseResult {
     }
 }
 
+// Helper class for parsing rule to segments
 class RuleParser {
     private final Pattern rule_re = Pattern.compile(
             "(?<static>[^<]*)<(?:(?<converter>[a-zA-Z_][a-zA-Z0-9_]*)(?:\\((?<args>.*?)\\))?\\:)?(?<variable>[a-zA-Z_][a-zA-Z0-9_]*)>"

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
@@ -1,0 +1,24 @@
+package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class Rule implements RuleFactory {
+    public Rule(String string, Object endpoint) {
+
+    }
+    @Override
+    public ArrayList<Rule> getRules() {
+        return new ArrayList<>();
+    }
+    public void bind(Map map) {
+
+    }
+    public void compile() {
+
+    }
+    public HashMap<Object, Object> match() {
+        return null;
+    }
+}
+

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/RuleFactory.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/RuleFactory.java
@@ -3,5 +3,5 @@ package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
 import java.util.ArrayList;
 
 public interface RuleFactory {
-    public ArrayList<Rule> getRules();
+  public ArrayList<Rule> getRules();
 }

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/RuleFactory.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/RuleFactory.java
@@ -1,0 +1,7 @@
+package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
+
+import java.util.ArrayList;
+
+public interface RuleFactory {
+    public ArrayList<Rule> getRules();
+}

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapterTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapterTest.java
@@ -1,57 +1,51 @@
 package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
 
+import static org.testng.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.HashMap;
-
 import javafx.util.Pair;
-
 import org.testng.annotations.Test;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertSame;
 
 public class MapAdapterTest {
-    private MapAdapter exampleUrls() {
-        ArrayList<RuleFactory> rules = new ArrayList<>();
-        rules.add(new Rule("/", "index"));
-        rules.add(new Rule("/downloads/", "downloads/index"));
-        rules.add(new Rule("/downloads/<int:id>", "downloads/show"));
-        rules.add(new Rule("/date/<int:year>/<int:month>/<int:date>", "date"));
-        Map map = new Map(rules);
-        MapAdapter urls = map.bind("example.com");
-        return urls;
-    }
+  private MapAdapter exampleUrls() {
+    ArrayList<RuleFactory> rules = new ArrayList<>();
+    rules.add(new Rule("/", "index"));
+    rules.add(new Rule("/downloads/", "downloads/index"));
+    rules.add(new Rule("/downloads/<int:id>", "downloads/show"));
+    rules.add(new Rule("/date/<int:year>/<int:month>/<int:date>", "date"));
+    Map map = new Map(rules);
+    MapAdapter urls = map.bind("example.com");
+    return urls;
+  }
 
-    @Test
-    public void testMapAdapter() {
-        MapAdapter urls = this.exampleUrls();
-    }
+  @Test
+  public void testMapAdapter() {
+    MapAdapter urls = this.exampleUrls();
+  }
 
-    @Test
-    public void testMatch() {
-        MapAdapter urls = this.exampleUrls();
-        Pair<String, HashMap<String, Integer>> result;
-        result = urls.match("/");
-        assertEquals(result.getKey(), "index");
-        assertEquals(result.getValue().size(), 0);
+  @Test
+  public void testMatch() {
+    MapAdapter urls = this.exampleUrls();
+    Pair<String, HashMap<String, Integer>> result;
+    result = urls.match("/");
+    assertEquals(result.getKey(), "index");
+    assertEquals(result.getValue().size(), 0);
 
-        result = urls.match("/downloads/");
-        assertEquals(result.getKey(), "downloads/index");
-        assertEquals(result.getValue().size(), 0);
+    result = urls.match("/downloads/");
+    assertEquals(result.getKey(), "downloads/index");
+    assertEquals(result.getValue().size(), 0);
 
-        result = urls.match("/downloads/12");
-        assertEquals(result.getKey(), "downloads/show");
-        assertEquals(result.getValue().size(), 1);
-        assertEquals(result.getValue().get("id"), new Integer(12));
+    result = urls.match("/downloads/12");
+    assertEquals(result.getKey(), "downloads/show");
+    assertEquals(result.getValue().size(), 1);
+    assertEquals(result.getValue().get("id"), new Integer(12));
 
-        result = urls.match("/date/1996/8/25");
-        assertEquals(result.getKey(), "date");
-        assertEquals(result.getValue().size(), 3);
-        assertEquals(result.getValue().get("year"), new Integer(1996));
-        assertEquals(result.getValue().get("month"), new Integer(8));
-        assertEquals(result.getValue().get("date"), new Integer(25));
-    }
+    result = urls.match("/date/1996/8/25");
+    assertEquals(result.getKey(), "date");
+    assertEquals(result.getValue().size(), 3);
+    assertEquals(result.getValue().get("year"), new Integer(1996));
+    assertEquals(result.getValue().get("month"), new Integer(8));
+    assertEquals(result.getValue().get("date"), new Integer(25));
+  }
 }
-
-
-

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapterTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapterTest.java
@@ -1,0 +1,57 @@
+package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import javafx.util.Pair;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+
+public class MapAdapterTest {
+    private MapAdapter exampleUrls() {
+        ArrayList<RuleFactory> rules = new ArrayList<>();
+        rules.add(new Rule("/", "index"));
+        rules.add(new Rule("/downloads/", "downloads/index"));
+        rules.add(new Rule("/downloads/<int:id>", "downloads/show"));
+        rules.add(new Rule("/date/<int:year>/<int:month>/<int:date>", "date"));
+        Map map = new Map(rules);
+        MapAdapter urls = map.bind("example.com");
+        return urls;
+    }
+
+    @Test
+    public void testMapAdapter() {
+        MapAdapter urls = this.exampleUrls();
+    }
+
+    @Test
+    public void testMatch() {
+        MapAdapter urls = this.exampleUrls();
+        Pair<String, HashMap<String, Integer>> result;
+        result = urls.match("/");
+        assertEquals(result.getKey(), "index");
+        assertEquals(result.getValue().size(), 0);
+
+        result = urls.match("/downloads/");
+        assertEquals(result.getKey(), "downloads/index");
+        assertEquals(result.getValue().size(), 0);
+
+        result = urls.match("/downloads/12");
+        assertEquals(result.getKey(), "downloads/show");
+        assertEquals(result.getValue().size(), 1);
+        assertEquals(result.getValue().get("id"), new Integer(12));
+
+        result = urls.match("/date/1996/8/25");
+        assertEquals(result.getKey(), "date");
+        assertEquals(result.getValue().size(), 3);
+        assertEquals(result.getValue().get("year"), new Integer(1996));
+        assertEquals(result.getValue().get("month"), new Integer(8));
+        assertEquals(result.getValue().get("date"), new Integer(25));
+    }
+}
+
+
+

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapterTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapterTest.java
@@ -29,7 +29,7 @@ public class MapAdapterTest {
   @Test
   public void testMatch() {
     MapAdapter urls = this.exampleUrls();
-    Pair<String, HashMap<String, Integer>> result;
+    Pair<String, HashMap<String, Object>> result;
     result = urls.match("/");
     assertEquals(result.getKey(), "index");
     assertEquals(result.getValue().size(), 0);
@@ -41,13 +41,13 @@ public class MapAdapterTest {
     result = urls.match("/downloads/12");
     assertEquals(result.getKey(), "downloads/show");
     assertEquals(result.getValue().size(), 1);
-    assertEquals(result.getValue().get("id"), new Integer(12));
+    assertEquals((Integer) result.getValue().get("id"), new Integer(12));
 
     result = urls.match("/date/1996/8/25");
     assertEquals(result.getKey(), "date");
     assertEquals(result.getValue().size(), 3);
-    assertEquals(result.getValue().get("year"), new Integer(1996));
-    assertEquals(result.getValue().get("month"), new Integer(8));
-    assertEquals(result.getValue().get("date"), new Integer(25));
+    assertEquals((Integer) result.getValue().get("year"), new Integer(1996));
+    assertEquals((Integer) result.getValue().get("month"), new Integer(8));
+    assertEquals((Integer) result.getValue().get("date"), new Integer(25));
   }
 }

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapterTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapterTest.java
@@ -13,8 +13,10 @@ public class MapAdapterTest {
     rules.add(new Rule("/", "index"));
     rules.add(new Rule("/downloads/", "downloads/index"));
     rules.add(new Rule("/downloads/<int:id>", "downloads/show"));
-    rules.add(new Rule("/date/<int:year>/<int:month>/<int:date>", "date"));
+
     Map map = new Map(rules);
+    map.add(new Rule("/date/<int:year>/<int:month>/<int:date>", "date"));
+
     MapAdapter urls = map.bind("example.com");
     return urls;
   }

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapTest.java
@@ -1,15 +1,48 @@
 package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
+
+import manifold.ext.api.Jailbreak;
+import org.eclipse.jetty.server.Server;
 import org.testng.annotations.Test;
+import tw.edu.ntu.lowerbound10hours.jerkzeug.Application;
+import tw.edu.ntu.lowerbound10hours.jerkzeug.TestApplication;
+import tw.edu.ntu.lowerbound10hours.jerkzeug.serving.WsgiRequestHandler;
 
 public class MapTest {
-  @Test
-  public void testMap() {
+
+    private Map exampleMap() {
     ArrayList<RuleFactory> rules = new ArrayList<>();
     rules.add(new Rule("/", "index"));
     rules.add(new Rule("/downloads/", "downloads/index"));
     rules.add(new Rule("/downloads/<int:id>", "downloads/show"));
-    Map map = new Map(rules);
+    return new Map(rules);
+    }
+    private java.util.Map<String, Object> exampleEnvironment() {
+      int port = 8001;
+      String name = "localhost";
+      try {
+          InetAddress host = InetAddress.getByName(name);
+          Application testApp = new TestApplication();
+          Server testServer = new Server(new InetSocketAddress(host, port));
+          @Jailbreak WsgiRequestHandler handler = new WsgiRequestHandler(testApp, testServer);
+          java.util.Map<String, Object> environ = handler.makeEnviron(null, null, null, null);
+          return environ;
+      } catch (Exception e) {
+          return null;
+      }
+    } 
+  @Test
+  public void testMap() {
+    Map map = exampleMap();
+  }
+
+  @Test
+  public void testBindToEnviron() {
+      Map map = exampleMap();
+      java.util.Map<String, Object> environ = exampleEnvironment();
+      map.bindToEnvironment(environ, null, null);
   }
 }

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapTest.java
@@ -1,9 +1,12 @@
 package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
 
+import static org.testng.Assert.assertEquals;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
-
+import java.util.HashMap;
+import javafx.util.Pair;
 import manifold.ext.api.Jailbreak;
 import org.eclipse.jetty.server.Server;
 import org.testng.annotations.Test;
@@ -13,27 +16,29 @@ import tw.edu.ntu.lowerbound10hours.jerkzeug.serving.WsgiRequestHandler;
 
 public class MapTest {
 
-    private Map exampleMap() {
+  public Map exampleMap() {
     ArrayList<RuleFactory> rules = new ArrayList<>();
     rules.add(new Rule("/", "index"));
     rules.add(new Rule("/downloads/", "downloads/index"));
     rules.add(new Rule("/downloads/<int:id>", "downloads/show"));
     return new Map(rules);
+  }
+
+  public java.util.Map<String, Object> exampleEnvironment() {
+    int port = 8001;
+    String name = "localhost";
+    try {
+      InetAddress host = InetAddress.getByName(name);
+      Application testApp = new TestApplication();
+      Server testServer = new Server(new InetSocketAddress(host, port));
+      @Jailbreak WsgiRequestHandler handler = new WsgiRequestHandler(testApp, testServer);
+      java.util.Map<String, Object> environ = handler.makeEnviron(null, null, null, null);
+      return environ;
+    } catch (Exception e) {
+      return null;
     }
-    private java.util.Map<String, Object> exampleEnvironment() {
-      int port = 8001;
-      String name = "localhost";
-      try {
-          InetAddress host = InetAddress.getByName(name);
-          Application testApp = new TestApplication();
-          Server testServer = new Server(new InetSocketAddress(host, port));
-          @Jailbreak WsgiRequestHandler handler = new WsgiRequestHandler(testApp, testServer);
-          java.util.Map<String, Object> environ = handler.makeEnviron(null, null, null, null);
-          return environ;
-      } catch (Exception e) {
-          return null;
-      }
-    } 
+  }
+
   @Test
   public void testMap() {
     Map map = exampleMap();
@@ -41,8 +46,14 @@ public class MapTest {
 
   @Test
   public void testBindToEnviron() {
-      Map map = exampleMap();
-      java.util.Map<String, Object> environ = exampleEnvironment();
-      map.bindToEnvironment(environ, null, null);
+    Map map = exampleMap();
+    java.util.Map<String, Object> environ = exampleEnvironment();
+    MapAdapter urls = map.bindToEnvironment(environ, null, null);
+
+    Pair<String, HashMap<String, Object>> result;
+    result = urls.match("/downloads/12");
+    assertEquals(result.getKey(), "downloads/show");
+    assertEquals(result.getValue().size(), 1);
+    assertEquals((Integer) result.getValue().get("id"), new Integer(12));
   }
 }

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapTest.java
@@ -1,0 +1,20 @@
+package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
+
+import java.util.ArrayList;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+
+public class MapTest {
+    @Test
+    public void testMap() {
+        ArrayList<RuleFactory> rules = new ArrayList<>();
+        rules.add(new Rule("/", "index"));
+        rules.add(new Rule("/downloads/", "downloads/index"));
+        rules.add(new Rule("/downloads/<int:id>", "downloads/show"));
+        Map map = new Map(rules);
+    }
+}
+

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapTest.java
@@ -16,7 +16,7 @@ import tw.edu.ntu.lowerbound10hours.jerkzeug.serving.WsgiRequestHandler;
 
 public class MapTest {
 
-  public Map exampleMap() {
+  private Map exampleMap() {
     ArrayList<RuleFactory> rules = new ArrayList<>();
     rules.add(new Rule("/", "index"));
     rules.add(new Rule("/downloads/", "downloads/index"));
@@ -24,7 +24,7 @@ public class MapTest {
     return new Map(rules);
   }
 
-  public java.util.Map<String, Object> exampleEnvironment() {
+  private java.util.Map<String, Object> exampleEnvironment() {
     int port = 8001;
     String name = "localhost";
     try {

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapTest.java
@@ -1,20 +1,15 @@
 package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
 
 import java.util.ArrayList;
-
 import org.testng.annotations.Test;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertSame;
 
 public class MapTest {
-    @Test
-    public void testMap() {
-        ArrayList<RuleFactory> rules = new ArrayList<>();
-        rules.add(new Rule("/", "index"));
-        rules.add(new Rule("/downloads/", "downloads/index"));
-        rules.add(new Rule("/downloads/<int:id>", "downloads/show"));
-        Map map = new Map(rules);
-    }
+  @Test
+  public void testMap() {
+    ArrayList<RuleFactory> rules = new ArrayList<>();
+    rules.add(new Rule("/", "index"));
+    rules.add(new Rule("/downloads/", "downloads/index"));
+    rules.add(new Rule("/downloads/<int:id>", "downloads/show"));
+    Map map = new Map(rules);
+  }
 }
-

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/RuleTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/RuleTest.java
@@ -47,9 +47,9 @@ public class RuleTest {
     Rule rule = new Rule("/about/<int:year>/<int:month>", "about");
     Map map = this.getMapWithRule(rule);
 
-    HashMap<String, Integer> matchedResult = rule.match("|/about/1996/11");
+    HashMap<String, Object> matchedResult = rule.match("|/about/1996/11");
 
-    HashMap<String, Integer> answer = new HashMap<>();
+    HashMap<String, Object> answer = new HashMap<>();
     answer.put("year", new Integer(1996));
     answer.put("month", new Integer(11));
     assertEquals(matchedResult, answer);

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/RuleTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/RuleTest.java
@@ -1,56 +1,57 @@
 package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.regex.Pattern;
-
-import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
 
-public class RuleTest{
-    @Test
-    public void testGetRules() {
-        Rule rule = new Rule("/index", "index");
-        ArrayList<Rule> ret = rule.getRules();
-        assertSame(ret.get(0), rule);
-    }
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.regex.Pattern;
+import org.testng.annotations.Test;
 
-    @Test
-    public void testBind() {
-        Rule rule = new Rule("/index", "index");
-        Map map = new Map(new ArrayList<RuleFactory>());
-        boolean rebind = false;
+public class RuleTest {
+  @Test
+  public void testGetRules() {
+    Rule rule = new Rule("/index", "index");
+    ArrayList<Rule> ret = rule.getRules();
+    assertSame(ret.get(0), rule);
+  }
 
-        rule.bind(map, rebind);
-        assertSame(rule.getMap(), map);
-        assertNotNull(rule.getRegex());
-    }
+  @Test
+  public void testBind() {
+    Rule rule = new Rule("/index", "index");
+    Map map = new Map(new ArrayList<RuleFactory>());
+    boolean rebind = false;
 
-    private Map getMapWithRule(Rule rule) {
-        ArrayList<RuleFactory> rules = new ArrayList<RuleFactory>();
-        rules.add(rule);
-        return new Map(rules);
-    }
-    @Test
-    public void testCompileRegex() {
-        Rule rule = new Rule("/about/<int:year>/<int:month>", "about");
-        Map map = this.getMapWithRule(rule);
-        Pattern answer = Pattern.compile("^\\|/about/(?<year>-?\\d+)/(?<month>-?\\d+)");
-        assertEquals(rule.getRegex().pattern(), answer.pattern());
-    }
+    rule.bind(map, rebind);
+    assertSame(rule.getMap(), map);
+    assertNotNull(rule.getRegex());
+  }
 
-    @Test
-    public void testMatch() {
-        Rule rule = new Rule("/about/<int:year>/<int:month>", "about");
-        Map map = this.getMapWithRule(rule);
+  private Map getMapWithRule(Rule rule) {
+    ArrayList<RuleFactory> rules = new ArrayList<RuleFactory>();
+    rules.add(rule);
+    return new Map(rules);
+  }
 
-        HashMap<String, Integer> matchedResult = rule.match("|/about/1996/11");
+  @Test
+  public void testCompileRegex() {
+    Rule rule = new Rule("/about/<int:year>/<int:month>", "about");
+    Map map = this.getMapWithRule(rule);
+    Pattern answer = Pattern.compile("^\\|/about/(?<year>-?\\d+)/(?<month>-?\\d+)");
+    assertEquals(rule.getRegex().pattern(), answer.pattern());
+  }
 
-        HashMap<String, Integer> answer = new HashMap<>();
-        answer.put("year", new Integer(1996));
-        answer.put("month", new Integer(11));
-        assertEquals(matchedResult, answer);
-    }
+  @Test
+  public void testMatch() {
+    Rule rule = new Rule("/about/<int:year>/<int:month>", "about");
+    Map map = this.getMapWithRule(rule);
+
+    HashMap<String, Integer> matchedResult = rule.match("|/about/1996/11");
+
+    HashMap<String, Integer> answer = new HashMap<>();
+    answer.put("year", new Integer(1996));
+    answer.put("month", new Integer(11));
+    assertEquals(matchedResult, answer);
+  }
 }

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/RuleTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/RuleTest.java
@@ -1,6 +1,7 @@
 package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.regex.Pattern;
 
 import org.testng.annotations.Test;
@@ -27,31 +28,29 @@ public class RuleTest{
         assertNotNull(rule.getRegex());
     }
 
+    private Map getMapWithRule(Rule rule) {
+        ArrayList<RuleFactory> rules = new ArrayList<RuleFactory>();
+        rules.add(rule);
+        return new Map(rules);
+    }
     @Test
     public void testCompileRegex() {
         Rule rule = new Rule("/about/<int:year>/<int:month>", "about");
-        rule.compile();
-        Pattern ans = Pattern.compile("^/about/(?<year>-?\\d+)/(?<month>-?\\d+)");
-        assertEquals(rule.getRegex().pattern(), ans.pattern());
+        Map map = this.getMapWithRule(rule);
+        Pattern answer = Pattern.compile("^\\|/about/(?<year>-?\\d+)/(?<month>-?\\d+)");
+        assertEquals(rule.getRegex().pattern(), answer.pattern());
     }
-    // public void compile() {
-    //     /** compile the regular expression and stores it */
-    //     ArrayList<String> regex_parts = new ArrayList<String>();
-    //     for (ParseResult result: Utilities.parseRuleHelper(this.rule)) {
-    //         regex_parts.add(String.format(
-    //             "(?<%s>%s)", result.variable, result.converter.regex
-    //         ));
-    //     }
-    //     regex_parts.add("\\|");
-    //     // the second part "(?<!/)(?P<__suffix__>/?)" currently not supported.
-    //     String regex = String.format("^%s", String.join("", regex_parts));
-    //     this.regex = Pattern.compile(regex);
-    // }
-    // public HashMap<String, Integer> match(String path) {
-    //     /**Check if the rule matched a given path in the form "subdomain|/path" and
-    //      * is assembled by the Map. If matched, return converted values in a dict.
-    //      * Otherwise null will be returned.
-    //      */
-    //     return null;
-    // }
+
+    @Test
+    public void testMatch() {
+        Rule rule = new Rule("/about/<int:year>/<int:month>", "about");
+        Map map = this.getMapWithRule(rule);
+
+        HashMap<String, Integer> matchedResult = rule.match("|/about/1996/11");
+
+        HashMap<String, Integer> answer = new HashMap<>();
+        answer.put("year", new Integer(1996));
+        answer.put("month", new Integer(11));
+        assertEquals(matchedResult, answer);
+    }
 }

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/RuleTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/RuleTest.java
@@ -1,0 +1,57 @@
+package tw.edu.ntu.lowerbound10hours.jerkzeug.routing;
+
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+
+public class RuleTest{
+    @Test
+    public void testGetRules() {
+        Rule rule = new Rule("/index", "index");
+        ArrayList<Rule> ret = rule.getRules();
+        assertSame(ret.get(0), rule);
+    }
+
+    @Test
+    public void testBind() {
+        Rule rule = new Rule("/index", "index");
+        Map map = new Map(new ArrayList<RuleFactory>());
+        boolean rebind = false;
+
+        rule.bind(map, rebind);
+        assertSame(rule.getMap(), map);
+        assertNotNull(rule.getRegex());
+    }
+
+    @Test
+    public void testCompileRegex() {
+        Rule rule = new Rule("/about/<int:year>/<int:month>", "about");
+        rule.compile();
+        Pattern ans = Pattern.compile("^/about/(?<year>-?\\d+)/(?<month>-?\\d+)");
+        assertEquals(rule.getRegex().pattern(), ans.pattern());
+    }
+    // public void compile() {
+    //     /** compile the regular expression and stores it */
+    //     ArrayList<String> regex_parts = new ArrayList<String>();
+    //     for (ParseResult result: Utilities.parseRuleHelper(this.rule)) {
+    //         regex_parts.add(String.format(
+    //             "(?<%s>%s)", result.variable, result.converter.regex
+    //         ));
+    //     }
+    //     regex_parts.add("\\|");
+    //     // the second part "(?<!/)(?P<__suffix__>/?)" currently not supported.
+    //     String regex = String.format("^%s", String.join("", regex_parts));
+    //     this.regex = Pattern.compile(regex);
+    // }
+    // public HashMap<String, Integer> match(String path) {
+    //     /**Check if the rule matched a given path in the form "subdomain|/path" and
+    //      * is assembled by the Map. If matched, return converted values in a dict.
+    //      * Otherwise null will be returned.
+    //      */
+    //     return null;
+    // }
+}

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/serving/WsgiRequestHandlerTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/serving/WsgiRequestHandlerTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.Map;
 import manifold.ext.api.Jailbreak;
 import org.eclipse.jetty.server.Server;
 import org.testng.annotations.Test;
@@ -38,7 +39,7 @@ public class WsgiRequestHandlerTest {
     Server testServer = new Server(new InetSocketAddress(host, port));
     @Jailbreak WsgiRequestHandler handler = new WsgiRequestHandler(testApp, testServer);
     Map<String, Object> environ = handler.makeEnviron(null, null, null, null);
-    int serverPort = environ.get("SERVER_PORT");
+    int serverPort = (int) environ.get("SERVER_PORT");
     String serverName = environ.get("SERVER_NAME").toString();
     assertEquals(serverPort, port);
     assertEquals(serverName, name);

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/serving/WsgiRequestHandlerTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/serving/WsgiRequestHandlerTest.java
@@ -4,7 +4,6 @@ import static org.testng.Assert.assertEquals;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.util.Map;
 import manifold.ext.api.Jailbreak;
 import org.eclipse.jetty.server.Server;
 import org.testng.annotations.Test;
@@ -39,7 +38,7 @@ public class WsgiRequestHandlerTest {
     Server testServer = new Server(new InetSocketAddress(host, port));
     @Jailbreak WsgiRequestHandler handler = new WsgiRequestHandler(testApp, testServer);
     Map<String, Object> environ = handler.makeEnviron(null, null, null, null);
-    int serverPort = (Integer) environ.get("SERVER_PORT");
+    int serverPort = environ.get("SERVER_PORT");
     String serverName = environ.get("SERVER_NAME").toString();
     assertEquals(serverPort, port);
     assertEquals(serverName, name);


### PR DESCRIPTION
## Why do we need this PR?
* Add  implementation of werkzeug.routing (minimal version)
* For basic usage cases, please see the unit test in `src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapterTest.java` and `src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapTest.java`

## How is it implemented?
* Reference werkzeug.routing and implement it in Java

## Note
* werkzeug.routing.Map.bind_to_environment is used in Flask, but it's currently not implemented by Jerkzeug unless I know the implementation of `WSGI environment` in Jlask.
* A lot of exceptions raising/handling are ignored.
* Now only one type of url variable converter is implemented (i.e. RegexIntegerConverter). That is, the variable in a URL rule can only be `int` (e.g. `/about/<int:id>`)

#### PR readiness check list
> - [ v ] Did it pass the Checkstyle?
> - [ v ] Did you write tests for this PR?  
