### PR TITLE
Rename routing.Map as routing.RuleMap

### DIFF
--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapter.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapter.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 
 public class MapAdapter {
 
-  private Map map;
+  private RuleMap map;
   private String serverName;
   private String scriptName;
   private String subdomain;
@@ -14,11 +14,11 @@ public class MapAdapter {
   private String defaultMethod;
 
   /**
-   * Returned by :meth:`Map.bind` or :meth:`Map.bind_to_environ` and does the URL matching and
-   * building based on runtime information.
+   * Returned by :meth:`RuleMap.bind` or :meth:`RuleMap.bind_to_environ` and does the URL matching
+   * and building based on runtime information.
    */
   public MapAdapter(
-      Map map,
+      RuleMap map,
       String serverName,
       String scriptName,
       String subdomain,

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/Rule.java
@@ -12,7 +12,7 @@ public class Rule implements RuleFactory {
   public String endpoint;
   public String subdomain;
   public String host;
-  private Map map = null;
+  private RuleMap map = null;
   private Pattern regex;
   private HashMap<String, RegexConverter> usedConverter = new HashMap<>();
 
@@ -41,7 +41,7 @@ public class Rule implements RuleFactory {
    * Bind the url to a map and create a regular expression based on the information from the rule
    * itself and the defaults from the map.
    */
-  public void bind(Map map, boolean rebind) {
+  public void bind(RuleMap map, boolean rebind) {
     if (this.map != null && rebind) {
       throw new RuntimeException("Already bound.");
     }
@@ -98,7 +98,7 @@ public class Rule implements RuleFactory {
     }
   }
 
-  public Map getMap() {
+  public RuleMap getMap() {
     return this.map;
   }
 

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/RuleMap.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/RuleMap.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
-public class Map {
+public class RuleMap {
   public ArrayList<Rule> rules = new ArrayList<>();
   private HashMap<String, ArrayList<Rule>> rulesByEndpoint = new HashMap<>();
   private boolean remap = true;
@@ -13,7 +13,7 @@ public class Map {
   public boolean hostMatching = false;
 
   /** The map class stores all the URL rules and some configuration parameters. */
-  public Map(List<RuleFactory> ruleFactories, String defaultSubdomain, boolean hostMatching) {
+  public RuleMap(List<RuleFactory> ruleFactories, String defaultSubdomain, boolean hostMatching) {
     for (RuleFactory ruleFactory : ruleFactories) {
       this.add(ruleFactory);
     }
@@ -21,7 +21,7 @@ public class Map {
     this.hostMatching = hostMatching;
   }
 
-  public Map(List<RuleFactory> ruleFactories) {
+  public RuleMap(List<RuleFactory> ruleFactories) {
     this(ruleFactories, "", false);
   }
 

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapterTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapAdapterTest.java
@@ -14,7 +14,7 @@ public class MapAdapterTest {
     rules.add(new Rule("/downloads/", "downloads/index"));
     rules.add(new Rule("/downloads/<int:id>", "downloads/show"));
 
-    Map map = new Map(rules);
+    RuleMap map = new RuleMap(rules);
     map.add(new Rule("/date/<int:year>/<int:month>/<int:date>", "date"));
 
     MapAdapter urls = map.bind("example.com");

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/MapTest.java
@@ -16,12 +16,12 @@ import tw.edu.ntu.lowerbound10hours.jerkzeug.serving.WsgiRequestHandler;
 
 public class MapTest {
 
-  private Map exampleMap() {
+  private RuleMap exampleMap() {
     ArrayList<RuleFactory> rules = new ArrayList<>();
     rules.add(new Rule("/", "index"));
     rules.add(new Rule("/downloads/", "downloads/index"));
     rules.add(new Rule("/downloads/<int:id>", "downloads/show"));
-    return new Map(rules);
+    return new RuleMap(rules);
   }
 
   private java.util.Map<String, Object> exampleEnvironment() {
@@ -41,12 +41,12 @@ public class MapTest {
 
   @Test
   public void testMap() {
-    Map map = exampleMap();
+    RuleMap map = exampleMap();
   }
 
   @Test
   public void testBindToEnviron() {
-    Map map = exampleMap();
+    RuleMap map = exampleMap();
     java.util.Map<String, Object> environ = exampleEnvironment();
     MapAdapter urls = map.bindToEnvironment(environ, null, null);
 

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/RuleTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/routing/RuleTest.java
@@ -20,7 +20,7 @@ public class RuleTest {
   @Test
   public void testBind() {
     Rule rule = new Rule("/index", "index");
-    Map map = new Map(new ArrayList<RuleFactory>());
+    RuleMap map = new RuleMap(new ArrayList<RuleFactory>());
     boolean rebind = false;
 
     rule.bind(map, rebind);
@@ -28,16 +28,16 @@ public class RuleTest {
     assertNotNull(rule.getRegex());
   }
 
-  private Map getMapWithRule(Rule rule) {
+  private RuleMap getMapWithRule(Rule rule) {
     ArrayList<RuleFactory> rules = new ArrayList<RuleFactory>();
     rules.add(rule);
-    return new Map(rules);
+    return new RuleMap(rules);
   }
 
   @Test
   public void testCompileRegex() {
     Rule rule = new Rule("/about/<int:year>/<int:month>", "about");
-    Map map = this.getMapWithRule(rule);
+    RuleMap map = this.getMapWithRule(rule);
     Pattern answer = Pattern.compile("^\\|/about/(?<year>-?\\d+)/(?<month>-?\\d+)");
     assertEquals(rule.getRegex().pattern(), answer.pattern());
   }
@@ -45,7 +45,7 @@ public class RuleTest {
   @Test
   public void testMatch() {
     Rule rule = new Rule("/about/<int:year>/<int:month>", "about");
-    Map map = this.getMapWithRule(rule);
+    RuleMap map = this.getMapWithRule(rule);
 
     HashMap<String, Object> matchedResult = rule.match("|/about/1996/11");
 


### PR DESCRIPTION
## Why do we need this PR?
* routing.Map has a conflicting class name with java.util.Map, which is really commonly used.

## How is it implemented?
* Rename routing.Map to routing.RuleMap


#### PR readiness check list
> - [ v ] Did it pass the Checkstyle?
> - [ v ] Did you write tests for this PR?  
