### PR TITLE
Fix getCookies() return null check

### DIFF
--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/wrappers/Request.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/wrappers/Request.java
@@ -25,8 +25,10 @@ public class Request {
       this.baseRequest = (HttpServletRequest) environ.get("baseRequest");
       this.method = this.baseRequest.getMethod();
       this.cookies = new HashMap<String, Cookie>();
-      for (Cookie cookie : this.baseRequest.getCookies()) {
-        this.cookies.put(cookie.getName(), cookie);
+      if (this.baseRequest.getCookies() != null) {
+        for (Cookie cookie : this.baseRequest.getCookies()) {
+          this.cookies.put(cookie.getName(), cookie);
+        }
       }
     }
   }

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/wrappers/RequestTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/wrappers/RequestTest.java
@@ -12,12 +12,15 @@ import org.testng.annotations.Test;
 
 public class RequestTest {
   private static HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-
+  private static HttpServletRequest mockNoCookieRequest = mock(HttpServletRequest.class);
   /** Setting up mock object. */
   public RequestTest() {
     when(mockRequest.getMethod()).thenReturn("GET");
     when(mockRequest.getCookies()).thenReturn(new Cookie[] {new Cookie("name", "value")});
     when(mockRequest.getParameter("key")).thenReturn("value");
+
+    when(mockNoCookieRequest.getMethod()).thenReturn("GET");
+    when(mockNoCookieRequest.getCookies()).thenReturn(null);
   }
 
   @Test
@@ -28,6 +31,15 @@ public class RequestTest {
     assertEquals(req.method, "GET");
     assertEquals(req.cookies.size(), 1);
     assertEquals(req.cookies.get("name").getValue(), "value");
+  }
+
+  @Test
+  public void testNoCookieConstructor() throws Exception {
+    Map<String, Object> environ = new HashMap<>();
+    environ.put("baseRequest", mockNoCookieRequest);
+    Request req = new Request(environ);
+    assertEquals(req.method, "GET");
+    assertEquals(req.cookies.size(), 0);
   }
 
   @Test


### PR DESCRIPTION
## Why do we need this PR?
* Fix `Request` constructor failing when no cookies in `HttpServletRequest`.

## How is it implemented?
* Added logic to check if getCookies() returns null.


#### PR readiness check list
> - [ v ] Did it pass the Checkstyle?
> - [ v ] Did you write tests for this PR?  
