### PR TITLE
fix Request/Response constructor environ key

### DIFF
--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/wrappers/Request.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/wrappers/Request.java
@@ -22,8 +22,8 @@ public class Request {
    */
   public Request(Map<String, Object> environ) {
     this.environ = environ;
-    if (environ.containsKey("baseRequest")) {
-      this.baseRequest = (HttpServletRequest) environ.get("baseRequest");
+    if (environ.containsKey("request")) {
+      this.baseRequest = (HttpServletRequest) environ.get("request");
       this.method = this.baseRequest.getMethod();
       this.cookies = new HashMap<String, Cookie>();
       if (this.baseRequest.getCookies() != null) {

--- a/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/wrappers/Response.java
+++ b/src/main/java/tw/edu/ntu/lowerbound10hours/jerkzeug/wrappers/Response.java
@@ -26,7 +26,7 @@ public class Response {
   public Response(String rv, Map<String, Object> environ, int status) {
     this.response = new ArrayList<>();
     this.response.add(rv);
-    this.baseResponse = (HttpServletResponse) environ.get("baseResponse");
+    this.baseResponse = (HttpServletResponse) environ.get("response");
     this.status = status;
   }
 
@@ -39,7 +39,7 @@ public class Response {
    */
   public Response(List<String> rv, Map<String, Object> environ, int status) {
     this.response = rv;
-    this.baseResponse = (HttpServletResponse) environ.get("baseResponse");
+    this.baseResponse = (HttpServletResponse) environ.get("response");
     this.status = status;
   }
 

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/wrappers/RequestTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/wrappers/RequestTest.java
@@ -27,7 +27,7 @@ public class RequestTest {
   @Test
   public void testConstructor() throws Exception {
     Map<String, Object> environ = new HashMap<>();
-    environ.put("baseRequest", mockRequest);
+    environ.put("request", mockRequest);
     Request req = new Request(environ);
     assertEquals(req.method, "GET");
     assertEquals(req.cookies.size(), 1);
@@ -37,7 +37,7 @@ public class RequestTest {
   @Test
   public void testNoCookieConstructor() throws Exception {
     Map<String, Object> environ = new HashMap<>();
-    environ.put("baseRequest", mockNoCookieRequest);
+    environ.put("request", mockNoCookieRequest);
     Request req = new Request(environ);
     assertEquals(req.method, "GET");
     assertEquals(req.cookies.size(), 0);
@@ -46,7 +46,7 @@ public class RequestTest {
   @Test
   public void testGetParameter() throws Exception {
     Map<String, Object> environ = new HashMap<>();
-    environ.put("baseRequest", mockRequest);
+    environ.put("request", mockRequest);
     Request req = new Request(environ);
     assertEquals(req.getParameter("key"), "value");
   }

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/wrappers/ResponseTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jerkzeug/wrappers/ResponseTest.java
@@ -32,7 +32,7 @@ public class ResponseTest {
   @Test
   public void testConstructor() throws Exception {
     Map<String, Object> environ = new HashMap<>();
-    environ.put("baseResponse", mockResponse);
+    environ.put("response", mockResponse);
     @Jailbreak Response res = new Response("foo", environ, 200);
     assertEquals(res.response.get(0), "foo");
   }
@@ -40,7 +40,7 @@ public class ResponseTest {
   @Test
   public void testListConstructor() throws Exception {
     Map<String, Object> environ = new HashMap<>();
-    environ.put("baseResponse", mockResponse);
+    environ.put("response", mockResponse);
     List<String> list = new ArrayList<>();
     list.add("foo");
     @Jailbreak Response res = new Response(list, environ, 200);
@@ -50,7 +50,7 @@ public class ResponseTest {
   @Test
   public void testSetCookie() throws Exception {
     Map<String, Object> environ = new HashMap<>();
-    environ.put("baseResponse", mockResponse);
+    environ.put("response", mockResponse);
     Response res = new Response("foo", environ, 200);
     res.setCookie("key", "value", "domain", "path", 0);
   }
@@ -58,7 +58,7 @@ public class ResponseTest {
   @Test
   public void testDeleteCookie() throws Exception {
     Map<String, Object> environ = new HashMap<>();
-    environ.put("baseResponse", mockResponse);
+    environ.put("response", mockResponse);
     Response res = new Response("foo", environ, 200);
     res.deleteCookie("key");
   }
@@ -66,7 +66,7 @@ public class ResponseTest {
   @Test
   public void testRedirect() throws Exception {
     Map<String, Object> environ = new HashMap<>();
-    environ.put("baseResponse", mockResponse);
+    environ.put("response", mockResponse);
     Response res = new Response("foo", environ, 200);
     res.sendRedirect("");
   }
@@ -74,7 +74,7 @@ public class ResponseTest {
   @Test
   public void testGetStatus() throws Exception {
     Map<String, Object> environ = new HashMap<>();
-    environ.put("baseResponse", mockResponse);
+    environ.put("response", mockResponse);
     @Jailbreak Response res1 = new Response("foo", environ, 200);
     assertEquals(res1.getStatus(), 200);
     @Jailbreak Response res2 = new Response("bar", environ, 404);
@@ -84,7 +84,7 @@ public class ResponseTest {
   @Test
   public void testGetResponseHeaders() throws Exception {
     Map<String, Object> environ = new HashMap<>();
-    environ.put("baseResponse", mockResponse);
+    environ.put("response", mockResponse);
     @Jailbreak Response res = new Response("foo", environ, 200);
     assertEquals(res.getResponseHeaders(environ).size(), 0);
   }
@@ -92,7 +92,7 @@ public class ResponseTest {
   @Test
   public void testGetApplicationIter() throws Exception {
     Map<String, Object> environ = new HashMap<>();
-    environ.put("baseResponse", mockResponse);
+    environ.put("response", mockResponse);
     @Jailbreak Response res = new Response("foo", environ, 200);
     assertEquals(res.getApplicationIter(environ).iterator().next(), "foo");
   }
@@ -100,7 +100,7 @@ public class ResponseTest {
   @Test
   public void testCall() throws Exception {
     Map<String, Object> environ = new HashMap<>();
-    environ.put("baseResponse", mockResponse);
+    environ.put("response", mockResponse);
     @Jailbreak Response res = new Response("foo", environ, 200);
     ApplicationIter<String> iter = res.call(environ, mockStartResponse);
     assertEquals(iter.iterator().next(), "foo");

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jlask/JlaskTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jlask/JlaskTest.java
@@ -60,7 +60,7 @@ public class JlaskTest {
   private Jlask buildAppAndSendReuqest() {
     @Jailbreak Jlask testApp = buildApp();
     Map<String, Object> environ = new HashMap<String, Object>();
-    environ.put("baseRequest", mockedRequest);
+    environ.put("request", mockedRequest);
     RequestContext ctx = new RequestContext(testApp, environ);
     ctx.push();
     return testApp;

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jlask/session/SecureCookieSessionInterfaceTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jlask/session/SecureCookieSessionInterfaceTest.java
@@ -48,12 +48,12 @@ public class SecureCookieSessionInterfaceTest {
 
     // set up fake request
     Map<String, Object> environ = new HashMap<>();
-    environ.put("baseRequest", mockRequest);
+    environ.put("request", mockRequest);
     Request request = new Request(environ);
     this.request = request;
 
     // set up fake response
-    environ.put("baseResponse", mockResponse);
+    environ.put("response", mockResponse);
     @Jailbreak Response response = new Response("foo", environ, 200);
     this.response = response;
   }

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jlask/wrappers/RequestTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jlask/wrappers/RequestTest.java
@@ -23,7 +23,7 @@ public class RequestTest {
   @Test
   public void testConstructor() throws Exception {
     Map<String, Object> environ = new HashMap<>();
-    environ.put("baseRequest", mockRequest);
+    environ.put("request", mockRequest);
     Request req = new Request(environ);
     assertEquals(req.method, "GET");
     assertEquals(req.cookies.size(), 1);
@@ -33,7 +33,7 @@ public class RequestTest {
   @Test
   public void testGetParameter() throws Exception {
     Map<String, Object> environ = new HashMap<>();
-    environ.put("baseRequest", mockRequest);
+    environ.put("request", mockRequest);
     Request req = new Request(environ);
     assertEquals(req.getParameter("key"), "value");
   }

--- a/src/test/java/tw/edu/ntu/lowerbound10hours/jlask/wrappers/ResponseTest.java
+++ b/src/test/java/tw/edu/ntu/lowerbound10hours/jlask/wrappers/ResponseTest.java
@@ -15,7 +15,7 @@ public class ResponseTest {
   @Test
   public void testConstructor() throws Exception {
     Map<String, Object> environ = new HashMap<>();
-    environ.put("baseResponse", mockResponse);
+    environ.put("response", mockResponse);
     @Jailbreak Response res = new Response("foo", environ, 200);
     assertEquals(res.response.get(0), "foo");
   }


### PR DESCRIPTION
## Why do we need this PR?
* Fix error key name in `Request` & `Response` constructor

## How is it implemented?
* Change from baseRequest to request, baseResponse to response


#### PR readiness check list
> - [ v ] Did it pass the Checkstyle?
> - [ v ] Did you write tests for this PR?  
